### PR TITLE
fix-for-nodes-without-inputs

### DIFF
--- a/js/extension.js
+++ b/js/extension.js
@@ -332,7 +332,11 @@ app.registerExtension({
 
 		const orig = LGraphCanvas.prototype.getNodeMenuOptions;
         LGraphCanvas.prototype.getNodeMenuOptions = function(node) {			
-			const options = orig.call(this, node);			
+			const options = orig.call(this, node);
+
+			if (!node.widgets) {
+				return options;
+			}
 
 			const loadOptions = presetManager.presets[node.type]?.map((preset) => ({
 				content: preset.name,


### PR DESCRIPTION
Disable the extension when a node doesn't have any inputs